### PR TITLE
full— [.WATCH.] Kung Fu Panda 4 (2024) (+FullMovie) Free Online on 123Movies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,81 @@
-# dsgvdfhb
+<h1>**WATCH@!∿ Kung Fu Panda 4 (2024) FuLLMovie (.Download.) Free 720p, 1080p, 480p HD</h2>
+
+
+𝙹𝚞𝚜𝚝 𝚊 𝚖𝚘𝚖𝚎𝚗𝚝 ago - While several avenues exist to view the highly praised film Kung Fu Panda 4 online streaming offers a versatile means to access its cinematic wonder From heartfelt songs to buoyant humor this genre-bending work explores the power of friendship to upKung Fu Panda 4 communities during troubling times Directed with nuanced color and vivacious animation lighter moments are blended seamlessly with touching introspection Cinephiles and casual fans alike will find their spirits Kung Fu Panda 4ed by this inspirational story of diverse characters joining in solidarity Why not spend an evening immersed in the vibrant world of Kung Fu Panda 4? Don't miss out!
+
+** LAST UPDATED : MARCH 8, 2024 **
+
+
+
+
+Kung Fu Panda 4 cinematic universe was expanded on November 20th with the release of The Ballad of Songbirds and Snakes in theaters However not everyone wants to experience the intense emotions that come with high-stakes drama and romance in a public setting If you prefer the comfort of streaming and the possibility of shedding a tear in the privacy of your living room you may have to wait a bit longer
+
+The Ballad of Songbirds and Snakes is an adaptation of Suzanne Collins' novel of the same name which was published in 2020 The story focuses on Coriolanus Snow who eventually becomes President Snow and has a tumultuous relationship with Katniss Everdeen In this new adaptation Tom Blyth portrays a young Coriolanus while Rachel Zegler plays Lucy Gray Baird the erased District 12 victor of the 10th annual Hunger Games
+
+The 2024 Demon Slayer movie is expected to play on IMAX screens and other Premium Large-Format screens. It's estimated that To the Hashira Training will open in between 1,600-1,800 theaters in the United States and Canada, Another important note is that two versions will play in domestic theaters: one in Japanese with English subtitles and another dubbed-over version with English-speaking characters. Box office expectations are mixed after a fantastic $49.9 million domestic haul back in 2021 with The Movie: Mugen Train, followed by an understated $16.9 million To the Swordsmith Village last year.
+
+Coriolanus is tasked with mentoring Lucy a responsibility for which he feels a sense of pride However Lucy's charm captivates the audience of Panem as she fights for her life and the well-being of her district They form an unconventional alliance that may even develop into an unlikely romance But is their fate already sealed? Fans of the Kung Fu Panda 4al Hunger Games trilogy know the answer but the journey towards that outcome is a thrilling adventure
+
+The prequel film is distributed by Lionsgate and collides with Peacock a streaming service through a multiyear agreement as reported by Collider Consequently it is highly likely that the movie will be available for streaming on that platform upon its release The agreement is set to take effect in 2024 so keep an eye out for The Ballad of Songbirds and Snakes then
+
+To prepare for this highly anticipated moment viewers can subscribe to Peacock starting at $599 per month or take advantage of a discounted annual rate of $5999 Peacock not only offers major releases but also provides access to live sports events and popular shows on NBC Bravo and numerous other popular channels
+
+WHEN AND WHERE WILL Kung Fu Panda 4 BE STREAMING?
+
+The new Kung Fu Panda 4 prequel Kung Fu Panda 4 will be available for streaming first on Starz for subscribers Later on the movie will also be released on Peacock thanks to the agreement between distributor Lionsgate and the NBC Universal streaming platform Determining the exact arrival date of the movie is a slightly more complex matter Typically Lionsgate movies like John Wick 4 take approximately six months to become available on Starz where they tend to remain for a considerable period As for when Songbirds Snakes will be accessible on Peacock it could take nearly a year after its release although we will only receive confirmation once Lionsgate makes an official announcement However if you Kung Fu Panda 4 to watch the movie even earlier you can rent it on Video on Demand (VOD) which will likely be available before the streaming date on Starz
+
+WHERE CAN I STREAM THE Kung Fu Panda 4AL Kung Fu Panda 4 MOVIES IN THE MEANTIME?
+
+In the meantime you can currently stream all four Kung Fu Panda 4al Kung Fu Panda 4 movies on Peacock until the end of November The availability of Kung Fu Panda 4 movies on Peacock varies depending on the month so make sure to take advantage of the current availability
+
+HOW TO WATCH Kung Fu Panda 4 2024 ONLINE:
+
+As of now, the only way to watch Kung Fu Panda 4 is to head out to a movie theater when it releases on Friday, September 8. You can find a local showing on Fandango. Otherwise, you'll have to wait until it becomes available to rent or purchase on digital platforms like Vudu, Apple, YouTube, and Amazon or available to stream on Max. Kung Fu Panda 4 is still currently in theaters if you want to experience all the film's twists and turns in a traditional cinema. But there's also now an option to watch the film at home. As of November 25, 2024, Kung Fu Panda 4 is available on HBO Max. Only those with a subscription to the service can watch the movie. Because the film is distributed by 20th Century Studios, it's one of the last films of the year to head to HBO Max due to a streaming deal in lieu of Disney acquiring 20th Century Studios, as Variety reports. At the end of 2024, 20th Century Studios' films will head to Hulu or Disney+ once they leave theaters.
+
+IS Kung Fu Panda 4 MOVIE ON NETFLIX, CRUNCHYROLL, HULU, OR AMAZON PRIME?
+
+Netflix: Kung Fu Panda 4 is currently not available on Netflix. However, fans of dark fantasy films can explore other thrilling options such as Doctor Strange to keep themselves entertained.
+
+Crunchyroll: Crunchyroll and Funimation have acquired the rights to distribute Kung Fu Panda 4 in North America. Stay tuned for its release on the platform in the coming months. In the meantime, indulge in dark fantasy shows like Spider-man to fulfill your entertainment needs.
+
+Hulu: Unfortunately, Kung Fu Panda 4 is not available for streaming on Hulu. However, Hulu offers a variety of other exciting options like Afro Samurai Resurrection or Ninja Scroll to keep you entertained.
+
+Disney+: Kung Fu Panda 4 is not currently available for streaming on Disney+. Fans will have to wait until late December, when it is expected to be released on the platform. Disney typically releases its films on Disney+ around 45-60 days after their theatrical release, ensuring an immersive cinematic experience for viewers.
+
+IS Kung Fu Panda 4 ON AMAZON PRIME VIDEO?Kung Fu Panda 4 movie could eventually be available to watch on Prime Video, though it will likely be a paid digital release rather than being included with an Amazon Prime subscription. This means that rather than watching the movie as part of an existing subscription fee, you may have to pay money to rent the movie digitally on Amazon. However, Warner Bros. and Amazon have yet to discuss whether or not this will be the case.
+
+WHEN WILL 'Kung Fu Panda 4', BE AVAILABLE ON BLU-RAY AND DVD?
+
+As of right now, we don't know. While the film will eventually land on Blu-ray, DVD, and 4K Ultra HD, Warner Bros has yet to reveal a specific date as to when that would be. The first Nun film also premiered in theaters in early September and was released on Blu-ray and DVD in December. Our best guess is that the sequel will follow a similar path and will be available around the holiday season.
+
+HERE'S HOW TO WATCH 'Kung Fu Panda 4' ONLINE STREAMING IN AUSTRALIA & NEW ZEALAND
+
+To watch 'Kung Fu Panda 4' (2022) for free online streaming in Australia and New Zealand, you can explore options like gomovies.one and gomovies.today, as mentioned in the search results. However, please note that the legality and safety of using such websites may vary, so exercise caution when accessing them. Additionally, you can check if the movie is available on popular streaming platforms like Netflix, Hulu, or Amazon Prime Video, as they often offer a wide selection of movies and TV.
+
+Here is a comprehensive guide on how to watch Kung Fu Panda 4 online in its entirety from the comfort of your own home. You can access the Full Movie free of charge on the respected platform known as 123Movies. Immerse yourself in the captivating experience of Kung Fu Panda 4 by watching it online for free. Alternatively, you can also enjoy the movie by downloading it in high definition. Enhance your movie viewing experience by watching Kung Fu Panda 4 on 123movies, a trusted source for online movie streaming.
+
+Heres How To Watch Kung Fu Panda 4 (2024) Online FullMovie At Home
+
+WATCH— Kung Fu Panda 4 Movie [2024] FullMovie Free Online ON 123MOVIES
+
+WATCH! Kung Fu Panda 4 (2024) (FullMovie) Free Online
+
+WATCH Kung Fu Panda 4 2024 (Online) Free FullMovie Download HD ON YIFY
+
+[WATCH] Kung Fu Panda 4 Movie (FullMovie) fRee Online on 123movies
+
+Kung Fu Panda 4 (FullMovie) Online Free on 123Movies
+
+Heres How To Watch Kung Fu Panda 4 Free Online At Home
+
+WATCH Kung Fu Panda 4(free) FULLMOVIE ONLINE ENGLISH/DUB/SUB STREAMING
+
+As for the rest of the box office there’s little to get excited about with nothing else grossing above $10 million as Hollywood shied away from releasing anything significant not just this weekend but also over the previous two weekends When Black Panther opened in 2018 there was no counterprogramming that opened the same weekend but Peter Rabbit and Fifty Shades Freed were in their second weekends and took second and third with $175 million and $173 million respectively That weekend had an overall cume of $287 million compared to $208 million this weekend Take away the $22 million gap between the two Black Panther films and there’s still a $57 million gap between the two weekends The difference may not feel that large when a mega blockbuster is propping up the grosses but the contrast is harsher when the mid-level films are the entire box office as we saw in recent months
+
+Kung Fu Panda 4which is the biKung Fu Panda 4est grosser of the rough post-summer pre-Wakanda Forever season came in second with just $86 million Despite the blockbuster competition that arrived in its fourth weekend the numbers didn’t totally collapse dropping 53 % for a cume of $151 million Worldwide it is at $352 million which isn’t a great cume as the grosses start to wind down considering its $200 million budget Still it’s the biKung Fu Panda 4est of any film since Kung Fu Panda 4though Wakanda Forever will overtake it any day nowKung Fu Panda 4came in third place in its fourth weekend down 29% with $61 million emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films for adults The domestic cume is $565 million Fourth place went to Lyle Lyle Crocodile which had a negligible drop of 5% for a $32 million sixth weekend and $408 million cume in fact)
+
+which isn’t surprising considering it’s the only family film on the market and it’s Kung Fu Panda 4to grossing four times its $114 million opening Still the $726 million worldwide cume is soft given the $50 million budget though a number of international markets have yet to open
+
+Finishing up the top five is Kung Fu Panda 4which had its biKung Fu Panda 4est weekend drop yet falling 42% for a $23 million seventh weekend Of course that’s no reason to frown for the horror film which has a domestic cume of $103 million and global cume of $ 210 million from a budget of just $20 million
+
+Kung Fu Panda 4came in third place in its fourth weekend, down 29% with $6.1 million, emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films


### PR DESCRIPTION
𝙹𝚞𝚜𝚝 𝚊 𝚖𝚘𝚖𝚎𝚗𝚝 ago - While several avenues exist to view the highly praised film Kung Fu Panda 4 online streaming offers a versatile means to access its cinematic wonder From heartfelt songs to buoyant humor this genre-bending work explores the power of friendship to upKung Fu Panda 4 communities during troubling times Directed with nuanced color and vivacious animation lighter moments are blended seamlessly with touching introspection Cinephiles and casual fans alike will find their spirits Kung Fu Panda 4ed by this inspirational story of diverse characters joining in solidarity Why not spend an evening immersed in the vibrant world of Kung Fu Panda 4? Don't miss out!





Kung Fu Panda 4 cinematic universe was expanded on November 20th with the release of The Ballad of Songbirds and Snakes in theaters However not everyone wants to experience the intense emotions that come with high-stakes drama and romance in a public setting If you prefer the comfort of streaming and the possibility of shedding a tear in the privacy of your living room you may have to wait a bit longer

The Ballad of Songbirds and Snakes is an adaptation of Suzanne Collins' novel of the same name which was published in 2020 The story focuses on Coriolanus Snow who eventually becomes President Snow and has a tumultuous relationship with Katniss Everdeen In this new adaptation Tom Blyth portrays a young Coriolanus while Rachel Zegler plays Lucy Gray Baird the erased District 12 victor of the 10th annual Hunger Games

The 2024 Demon Slayer movie is expected to play on IMAX screens and other Premium Large-Format screens. It's estimated that To the Hashira Training will open in between 1,600-1,800 theaters in the United States and Canada, Another important note is that two versions will play in domestic theaters: one in Japanese with English subtitles and another dubbed-over version with English-speaking characters. Box office expectations are mixed after a fantastic $49.9 million domestic haul back in 2021 with The Movie: Mugen Train, followed by an understated $16.9 million To the Swordsmith Village last year.

Coriolanus is tasked with mentoring Lucy a responsibility for which he feels a sense of pride However Lucy's charm captivates the audience of Panem as she fights for her life and the well-being of her district They form an unconventional alliance that may even develop into an unlikely romance But is their fate already sealed? Fans of the Kung Fu Panda 4al Hunger Games trilogy know the answer but the journey towards that outcome is a thrilling adventure

The prequel film is distributed by Lionsgate and collides with Peacock a streaming service through a multiyear agreement as reported by Collider Consequently it is highly likely that the movie will be available for streaming on that platform upon its release The agreement is set to take effect in 2024 so keep an eye out for The Ballad of Songbirds and Snakes then

To prepare for this highly anticipated moment viewers can subscribe to Peacock starting at $599 per month or take advantage of a discounted annual rate of $5999 Peacock not only offers major releases but also provides access to live sports events and popular shows on NBC Bravo and numerous other popular channels

WHEN AND WHERE WILL Kung Fu Panda 4 BE STREAMING?

The new Kung Fu Panda 4 prequel Kung Fu Panda 4 will be available for streaming first on Starz for subscribers Later on the movie will also be released on Peacock thanks to the agreement between distributor Lionsgate and the NBC Universal streaming platform Determining the exact arrival date of the movie is a slightly more complex matter Typically Lionsgate movies like John Wick 4 take approximately six months to become available on Starz where they tend to remain for a considerable period As for when Songbirds Snakes will be accessible on Peacock it could take nearly a year after its release although we will only receive confirmation once Lionsgate makes an official announcement However if you Kung Fu Panda 4 to watch the movie even earlier you can rent it on Video on Demand (VOD) which will likely be available before the streaming date on Starz

WHERE CAN I STREAM THE Kung Fu Panda 4AL Kung Fu Panda 4 MOVIES IN THE MEANTIME?

In the meantime you can currently stream all four Kung Fu Panda 4al Kung Fu Panda 4 movies on Peacock until the end of November The availability of Kung Fu Panda 4 movies on Peacock varies depending on the month so make sure to take advantage of the current availability

HOW TO WATCH Kung Fu Panda 4 2024 ONLINE:

As of now, the only way to watch Kung Fu Panda 4 is to head out to a movie theater when it releases on Friday, September 8. You can find a local showing on Fandango. Otherwise, you'll have to wait until it becomes available to rent or purchase on digital platforms like Vudu, Apple, YouTube, and Amazon or available to stream on Max. Kung Fu Panda 4 is still currently in theaters if you want to experience all the film's twists and turns in a traditional cinema. But there's also now an option to watch the film at home. As of November 25, 2024, Kung Fu Panda 4 is available on HBO Max. Only those with a subscription to the service can watch the movie. Because the film is distributed by 20th Century Studios, it's one of the last films of the year to head to HBO Max due to a streaming deal in lieu of Disney acquiring 20th Century Studios, as Variety reports. At the end of 2024, 20th Century Studios' films will head to Hulu or Disney+ once they leave theaters.

IS Kung Fu Panda 4 MOVIE ON NETFLIX, CRUNCHYROLL, HULU, OR AMAZON PRIME?

Netflix: Kung Fu Panda 4 is currently not available on Netflix. However, fans of dark fantasy films can explore other thrilling options such as Doctor Strange to keep themselves entertained.

Crunchyroll: Crunchyroll and Funimation have acquired the rights to distribute Kung Fu Panda 4 in North America. Stay tuned for its release on the platform in the coming months. In the meantime, indulge in dark fantasy shows like Spider-man to fulfill your entertainment needs.

Hulu: Unfortunately, Kung Fu Panda 4 is not available for streaming on Hulu. However, Hulu offers a variety of other exciting options like Afro Samurai Resurrection or Ninja Scroll to keep you entertained.

Disney+: Kung Fu Panda 4 is not currently available for streaming on Disney+. Fans will have to wait until late December, when it is expected to be released on the platform. Disney typically releases its films on Disney+ around 45-60 days after their theatrical release, ensuring an immersive cinematic experience for viewers.

IS Kung Fu Panda 4 ON AMAZON PRIME VIDEO?Kung Fu Panda 4 movie could eventually be available to watch on Prime Video, though it will likely be a paid digital release rather than being included with an Amazon Prime subscription. This means that rather than watching the movie as part of an existing subscription fee, you may have to pay money to rent the movie digitally on Amazon. However, Warner Bros. and Amazon have yet to discuss whether or not this will be the case.

WHEN WILL 'Kung Fu Panda 4', BE AVAILABLE ON BLU-RAY AND DVD?

As of right now, we don't know. While the film will eventually land on Blu-ray, DVD, and 4K Ultra HD, Warner Bros has yet to reveal a specific date as to when that would be. The first Nun film also premiered in theaters in early September and was released on Blu-ray and DVD in December. Our best guess is that the sequel will follow a similar path and will be available around the holiday season.

HERE'S HOW TO WATCH 'Kung Fu Panda 4' ONLINE STREAMING IN AUSTRALIA & NEW ZEALAND

To watch 'Kung Fu Panda 4' (2022) for free online streaming in Australia and New Zealand, you can explore options like gomovies.one and gomovies.today, as mentioned in the search results. However, please note that the legality and safety of using such websites may vary, so exercise caution when accessing them. Additionally, you can check if the movie is available on popular streaming platforms like Netflix, Hulu, or Amazon Prime Video, as they often offer a wide selection of movies and TV.

Here is a comprehensive guide on how to watch Kung Fu Panda 4 online in its entirety from the comfort of your own home. You can access the Full Movie free of charge on the respected platform known as 123Movies. Immerse yourself in the captivating experience of Kung Fu Panda 4 by watching it online for free. Alternatively, you can also enjoy the movie by downloading it in high definition. Enhance your movie viewing experience by watching Kung Fu Panda 4 on 123movies, a trusted source for online movie streaming.

Heres How To Watch Kung Fu Panda 4 (2024) Online FullMovie At Home

WATCH— Kung Fu Panda 4 Movie [2024] FullMovie Free Online ON 123MOVIES

WATCH! Kung Fu Panda 4 (2024) (FullMovie) Free Online

WATCH Kung Fu Panda 4 2024 (Online) Free FullMovie Download HD ON YIFY

[WATCH] Kung Fu Panda 4 Movie (FullMovie) fRee Online on 123movies

Kung Fu Panda 4 (FullMovie) Online Free on 123Movies

Heres How To Watch Kung Fu Panda 4 Free Online At Home

WATCH Kung Fu Panda 4(free) FULLMOVIE ONLINE ENGLISH/DUB/SUB STREAMING

As for the rest of the box office there’s little to get excited about with nothing else grossing above $10 million as Hollywood shied away from releasing anything significant not just this weekend but also over the previous two weekends When Black Panther opened in 2018 there was no counterprogramming that opened the same weekend but Peter Rabbit and Fifty Shades Freed were in their second weekends and took second and third with $175 million and $173 million respectively That weekend had an overall cume of $287 million compared to $208 million this weekend Take away the $22 million gap between the two Black Panther films and there’s still a $57 million gap between the two weekends The difference may not feel that large when a mega blockbuster is propping up the grosses but the contrast is harsher when the mid-level films are the entire box office as we saw in recent months

Kung Fu Panda 4which is the biKung Fu Panda 4est grosser of the rough post-summer pre-Wakanda Forever season came in second with just $86 million Despite the blockbuster competition that arrived in its fourth weekend the numbers didn’t totally collapse dropping 53 % for a cume of $151 million Worldwide it is at $352 million which isn’t a great cume as the grosses start to wind down considering its $200 million budget Still it’s the biKung Fu Panda 4est of any film since Kung Fu Panda 4though Wakanda Forever will overtake it any day nowKung Fu Panda 4came in third place in its fourth weekend down 29% with $61 million emerging as one of the season’s most durable grossers and one of the year’s few bright spots when it comes to films for adults The domestic cume is $565 million Fourth place went to Lyle Lyle Crocodile which had a negligible drop of 5% for a $32 million sixth weekend and $408 million cume in fact)

which isn’t surprising considering it’s the only family film on the market and it’s Kung Fu Panda 4to grossing four times its $114 million opening Still the $726 million worldwide cume is soft given the $50 million budget though a number of international markets have yet to open

Finishing up the top five is Kung Fu Panda 4which had its biKung Fu Panda 4est weekend drop yet falling 42% for a $23 million seventh weekend Of course that’s no reason to frown for the horror film which has a domestic cume of $103 million and global cume of $ 210 million from a budget of just $20 million